### PR TITLE
Clean up to_string and fix namespace literal test

### DIFF
--- a/src/builtins/to_string.c
+++ b/src/builtins/to_string.c
@@ -1,6 +1,6 @@
-// TEMP: enable trace for debugging t30
-#undef LS_TRACE
-#define LS_TRACE 1
+#ifndef LS_TRACE
+#define LS_TRACE 0
+#endif
 #include "runtime/effects.h"
 #include "thunk/thunk.h"
 #include "common/str.h"
@@ -11,22 +11,7 @@ lsthunk_t* lsbuiltin_to_string(lssize_t argc, lsthunk_t* const* args, void* data
   (void)argc;
   size_t len = 0; char* buf = NULL; FILE* fp = lsopen_memstream_gc(&buf, &len);
   lsthunk_t* v = lsthunk_eval0(args[0]);
-  if (!v) { 
-    #if LS_TRACE
-    lsprintf(stderr, 0, "DBG to_str: arg eval -> NULL\n");
-    #endif
-    fclose(fp); return NULL; }
-  #if LS_TRACE
-  {
-    const char* vt = "?";
-    switch (lsthunk_get_type(v)) {
-    case LSTTYPE_INT: vt = "int"; break; case LSTTYPE_STR: vt = "str"; break;
-    case LSTTYPE_ALGE: vt = "alge"; break; case LSTTYPE_APPL: vt = "appl"; break;
-    case LSTTYPE_LAMBDA: vt = "lambda"; break; case LSTTYPE_REF: vt = "ref"; break;
-    case LSTTYPE_CHOICE: vt = "choice"; break; case LSTTYPE_BUILTIN: vt = "builtin"; break; }
-    lsprintf(stderr, 0, "DBG to_str: arg type=%s\n", vt);
-  }
-  #endif
+  if (!v) { fclose(fp); return NULL; }
   lsthunk_dprint(fp, LSPREC_LOWEST, 0, v);
   fclose(fp);
   const lsstr_t* str = lsstr_new(buf, len);

--- a/test/t30_ns_literal_use.ls
+++ b/test/t30_ns_literal_use.ls
@@ -1,5 +1,5 @@
 !{
-  ns <- { Foo = 42; Inc = (\n -> (~add n 1)) };
+  ns <- { Foo = 42; Inc = (\~n -> (~add ~n 1)) };
   ~~println (~to_str ((~ns Foo)));
   ~~println (~to_str (((~ns Inc) 41)));
 };


### PR DESCRIPTION
## Summary
- remove temporary to_string debug traces and handle NULL without logging
- correct t30 namespace literal test to use bound parameter

## Testing
- `./test/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a4dec2bf108327974730c89ef846b0