### PR TITLE
Add #err-based error propagation

### DIFF
--- a/src/builtins/arith.c
+++ b/src/builtins/arith.c
@@ -16,6 +16,12 @@ lsthunk_t* lsbuiltin_add(lssize_t argc, lsthunk_t* const* args, void* data) {
   if (lsthunk_is_err(lhs)) return lhs;
   lsthunk_t* rhs = ls_eval_arg(args[1], "add: arg2");
   if (lsthunk_is_err(rhs)) return rhs;
+  if (!lhs || !rhs) {
+    #if LS_TRACE
+    lsprintf(stderr, 0, "DBG add: arg eval NULL\n");
+    #endif
+    return ls_make_err("add: arg eval");
+  }
   if (lsthunk_get_type(lhs) != LSTTYPE_INT || lsthunk_get_type(rhs) != LSTTYPE_INT) {
     return ls_make_err("add: invalid type");
   }
@@ -32,6 +38,7 @@ lsthunk_t* lsbuiltin_sub(lssize_t argc, lsthunk_t* const* args, void* data) {
   if (lsthunk_is_err(lhs)) return lhs;
   lsthunk_t* rhs = ls_eval_arg(args[1], "sub: arg2");
   if (lsthunk_is_err(rhs)) return rhs;
+  if (!lhs || !rhs) return ls_make_err("sub: arg eval");
   if (lsthunk_get_type(lhs) != LSTTYPE_INT || lsthunk_get_type(rhs) != LSTTYPE_INT) {
     return ls_make_err("sub: invalid type");
   }

--- a/src/builtins/ns.c
+++ b/src/builtins/ns.c
@@ -38,6 +38,7 @@ static lsthunk_t* lsbuiltin_ns_dispatch(lssize_t argc, lsthunk_t* const* args, v
   if (!ns || !ns->map) return ls_make_err("namespace: invalid");
   lsthunk_t* keyv = ls_eval_arg(args[0], "namespace: key");
   if (lsthunk_is_err(keyv)) return keyv;
+  if (!keyv) return ls_make_err("namespace: key eval");
   if (lsthunk_get_type(keyv) != LSTTYPE_ALGE || lsthunk_get_argc(keyv) != 0) {
     return ls_make_err("namespace: expected bare symbol");
   }
@@ -81,12 +82,14 @@ static lsthunk_t* lsbuiltin_ns_set(lssize_t argc, lsthunk_t* const* args, void* 
   (void)argc; lsns_t* ns = (lsns_t*)data; if (!ns || !ns->map) return ls_make_err("namespace: invalid");
   lsthunk_t* symv = ls_eval_arg(args[0], "namespace: __set key");
   if (lsthunk_is_err(symv)) return symv;
+  if (!symv) return ls_make_err("namespace: __set key eval");
   if (lsthunk_get_type(symv) != LSTTYPE_ALGE || lsthunk_get_argc(symv) != 0) {
     return ls_make_err("namespace: __set expects bare symbol");
   }
   const lsstr_t* s = lsthunk_get_constr(symv);
   lsthunk_t* val = ls_eval_arg(args[1], "namespace: __set value");
   if (lsthunk_is_err(val)) return val;
+  if (!val) return ls_make_err("namespace: __set value eval");
   lshash_data_t oldv; (void)lshash_put(ns->map, s, (const void*)val, &oldv);
   return ls_make_unit();
 }
@@ -105,6 +108,7 @@ lsthunk_t* lsbuiltin_nsnew(lssize_t argc, lsthunk_t* const* args, void* data) {
   lstenv_t* tenv = (lstenv_t*)data; if (!tenv) return NULL;
   lsthunk_t* namev = ls_eval_arg(args[0], "nsnew: name");
   if (lsthunk_is_err(namev)) return namev;
+  if (!namev) return ls_make_err("nsnew: name eval");
   if (lsthunk_get_type(namev) != LSTTYPE_ALGE || lsthunk_get_argc(namev) != 0) {
     return ls_make_err("nsnew: expected bare symbol");
   }
@@ -127,6 +131,7 @@ lsthunk_t* lsbuiltin_nsdef(lssize_t argc, lsthunk_t* const* args, void* data) {
   if (lsthunk_is_err(nsv)) return nsv;
   lsthunk_t* symv = ls_eval_arg(args[1], "nsdef: key");
   if (lsthunk_is_err(symv)) return symv;
+  if (!nsv || !symv) return ls_make_err("nsdef: arg eval");
   if (lsthunk_get_type(nsv) != LSTTYPE_ALGE || lsthunk_get_argc(nsv) != 0) {
     return ls_make_err("nsdef: expected ns symbol");
   }
@@ -147,6 +152,7 @@ lsthunk_t* lsbuiltin_nsdef(lssize_t argc, lsthunk_t* const* args, void* data) {
   lsns_t* ns = (lsns_t*)nsp; if (!ns || !ns->map) return ls_make_err("nsdef: invalid namespace");
   lsthunk_t* val = ls_eval_arg(args[2], "nsdef: value");
   if (lsthunk_is_err(val)) return val;
+  if (!val) return ls_make_err("nsdef: value eval");
   lshash_data_t oldv; (void)lshash_put(ns->map, symname, (const void*)val, &oldv);
   return ls_make_unit();
 }
@@ -167,6 +173,7 @@ lsthunk_t* lsbuiltin_nsdefv(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)argc; (void)data;
   lsthunk_t* nsv = ls_eval_arg(args[0], "nsdefv: ns");
   if (lsthunk_is_err(nsv)) return nsv;
+  if (!nsv) return ls_make_err("nsdefv: ns eval");
   // Accept either a namespace value (builtin carrying ns pointer) or a bare symbol
   lsns_t* ns = NULL;
   if (lsthunk_is_builtin(nsv)) {
@@ -185,12 +192,14 @@ lsthunk_t* lsbuiltin_nsdefv(lssize_t argc, lsthunk_t* const* args, void* data) {
   }
   lsthunk_t* symv = ls_eval_arg(args[1], "nsdefv: key");
   if (lsthunk_is_err(symv)) return symv;
+  if (!symv) return ls_make_err("nsdefv: key eval");
   if (lsthunk_get_type(symv) != LSTTYPE_ALGE || lsthunk_get_argc(symv) != 0) {
     return ls_make_err("nsdefv: expected bare symbol");
   }
   const lsstr_t* symname = lsthunk_get_constr(symv);
   lsthunk_t* val = ls_eval_arg(args[2], "nsdefv: value");
   if (lsthunk_is_err(val)) return val;
+  if (!val) return ls_make_err("nsdefv: value eval");
   if (NS_DLOG_ENABLED) {
     lsprintf(stderr, 0, "DBG nsdefv put ns=%p ", (void*)ns);
     lsstr_print_bare(stderr, LSPREC_LOWEST, 0, symname);

--- a/src/builtins/seq.c
+++ b/src/builtins/seq.c
@@ -15,6 +15,8 @@ lsthunk_t* lsbuiltin_seq(lssize_t argc, lsthunk_t* const* args, void* data) {
   lsthunk_t* fst_evaled = ls_eval_arg(fst, "seq: first");
   ls_effects_end();
   if (lsthunk_is_err(fst_evaled)) return fst_evaled;
+  if (fst_evaled == NULL)
+    return ls_make_err("seq: first eval");
   switch ((lsseq_type_t)(intptr_t)data) {
   case LSSEQ_SIMPLE:
     return snd;

--- a/src/builtins/to_string.c
+++ b/src/builtins/to_string.c
@@ -13,6 +13,7 @@ lsthunk_t* lsbuiltin_to_string(lssize_t argc, lsthunk_t* const* args, void* data
   size_t len = 0; char* buf = NULL; FILE* fp = lsopen_memstream_gc(&buf, &len);
   lsthunk_t* v = ls_eval_arg(args[0], "to_string: arg");
   if (lsthunk_is_err(v)) { fclose(fp); return v; }
+  if (!v) { fclose(fp); return ls_make_err("to_string: arg eval"); }
   lsthunk_dprint(fp, LSPREC_LOWEST, 0, v);
   fclose(fp);
   const lsstr_t* str = lsstr_new(buf, len);


### PR DESCRIPTION
## Summary
- introduce `#err` algebraic value and helpers
- propagate errors through builtins and thunk evaluation
- surface uncaught `#err` values as user-facing errors
- document required build dependencies
- update missing module test to expect new `#err` message

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a5049f055c8327987efcd8d208a5fa