### PR TITLE
Add #err-based error propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+To build this project, ensure the following packages are installed:
+
+- `build-essential` (provides `gcc`, `g++`, `make`)
+- `autoconf`
+- `automake`
+- `libtool`
+- `pkg-config`
+- `flex` (>= 2.6)
+- `bison` (>= 3.x)
+- `libgc-dev` (Boehm-Demers-Weiser garbage collector)
+- `doxygen` and `graphviz` (optional, for documentation)
+
+Typical build steps:
+
+```sh
+autoreconf -i
+./configure
+make -j$(nproc)
+```

--- a/src/builtins/arith.c
+++ b/src/builtins/arith.c
@@ -5,22 +5,19 @@
 #include "thunk/thunk.h"
 #include "common/str.h"
 #include "common/io.h"
+#include "runtime/error.h"
 
 lsthunk_t* lsbuiltin_add(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)data; (void)argc;
   #if LS_TRACE
   lsprintf(stderr, 0, "DBG add: begin\n");
   #endif
-  lsthunk_t* lhs = lsthunk_eval0(args[0]);
-  lsthunk_t* rhs = lsthunk_eval0(args[1]);
-  if (!lhs || !rhs) { 
-    #if LS_TRACE
-    lsprintf(stderr, 0, "DBG add: arg eval NULL\n");
-    #endif
-    return NULL; }
+  lsthunk_t* lhs = ls_eval_arg(args[0], "add: arg1");
+  if (lsthunk_is_err(lhs)) return lhs;
+  lsthunk_t* rhs = ls_eval_arg(args[1], "add: arg2");
+  if (lsthunk_is_err(rhs)) return rhs;
   if (lsthunk_get_type(lhs) != LSTTYPE_INT || lsthunk_get_type(rhs) != LSTTYPE_INT) {
-    lsprintf(stderr, 0, "E: add: invalid type\n");
-    return NULL;
+    return ls_make_err("add: invalid type");
   }
   lsthunk_t* ret = lsthunk_new_int(lsint_add(lsthunk_get_int(lhs), lsthunk_get_int(rhs)));
   #if LS_TRACE
@@ -31,12 +28,12 @@ lsthunk_t* lsbuiltin_add(lssize_t argc, lsthunk_t* const* args, void* data) {
 
 lsthunk_t* lsbuiltin_sub(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)data; (void)argc;
-  lsthunk_t* lhs = lsthunk_eval0(args[0]);
-  lsthunk_t* rhs = lsthunk_eval0(args[1]);
-  if (!lhs || !rhs) return NULL;
+  lsthunk_t* lhs = ls_eval_arg(args[0], "sub: arg1");
+  if (lsthunk_is_err(lhs)) return lhs;
+  lsthunk_t* rhs = ls_eval_arg(args[1], "sub: arg2");
+  if (lsthunk_is_err(rhs)) return rhs;
   if (lsthunk_get_type(lhs) != LSTTYPE_INT || lsthunk_get_type(rhs) != LSTTYPE_INT) {
-    lsprintf(stderr, 0, "E: sub: invalid type\n");
-    return NULL;
+    return ls_make_err("sub: invalid type");
   }
   return lsthunk_new_int(lsint_sub(lsthunk_get_int(lhs), lsthunk_get_int(rhs)));
 }

--- a/src/builtins/print.c
+++ b/src/builtins/print.c
@@ -2,6 +2,7 @@
 #include "thunk/thunk.h"
 #include "common/str.h"
 #include "common/io.h"
+#include "runtime/error.h"
 
 lsthunk_t* lsbuiltin_to_string(lssize_t argc, lsthunk_t* const* args, void* data);
 
@@ -11,9 +12,11 @@ lsthunk_t* lsbuiltin_print(lssize_t argc, lsthunk_t* const* args, void* data) {
     lsprintf(stderr, 0, "E: print: effect used in pure context (enable seq/chain or run with effects)\n");
     return NULL;
   }
-  lsthunk_t* thunk_str = lsthunk_eval0(args[0]);
+  lsthunk_t* thunk_str = ls_eval_arg(args[0], "print: arg");
+  if (lsthunk_is_err(thunk_str)) return thunk_str;
   if (lsthunk_get_type(thunk_str) != LSTTYPE_STR)
     thunk_str = lsbuiltin_to_string(1, args, data);
+  if (lsthunk_is_err(thunk_str)) return thunk_str;
   const lsstr_t* str = lsthunk_get_str(thunk_str);
   lsstr_print_bare(stdout, LSPREC_LOWEST, 0, str);
   return args[0];

--- a/src/builtins/seq.c
+++ b/src/builtins/seq.c
@@ -2,6 +2,7 @@
 #include "thunk/thunk.h"
 #include "common/str.h"
 #include "common/io.h"
+#include "runtime/error.h"
 #include <stdint.h>
 
 typedef enum lsseq_type { LSSEQ_SIMPLE, LSSEQ_CHAIN } lsseq_type_t;
@@ -11,10 +12,9 @@ lsthunk_t* lsbuiltin_seq(lssize_t argc, lsthunk_t* const* args, void* data) {
   lsthunk_t* fst = args[0];
   lsthunk_t* snd = args[1];
   ls_effects_begin();
-  lsthunk_t* fst_evaled = lsthunk_eval0(fst);
+  lsthunk_t* fst_evaled = ls_eval_arg(fst, "seq: first");
   ls_effects_end();
-  if (fst_evaled == NULL)
-    return NULL;
+  if (lsthunk_is_err(fst_evaled)) return fst_evaled;
   switch ((lsseq_type_t)(intptr_t)data) {
   case LSSEQ_SIMPLE:
     return snd;

--- a/src/builtins/to_string.c
+++ b/src/builtins/to_string.c
@@ -5,13 +5,14 @@
 #include "thunk/thunk.h"
 #include "common/str.h"
 #include "common/io.h"
+#include "runtime/error.h"
 
 lsthunk_t* lsbuiltin_to_string(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)data;
   (void)argc;
   size_t len = 0; char* buf = NULL; FILE* fp = lsopen_memstream_gc(&buf, &len);
-  lsthunk_t* v = lsthunk_eval0(args[0]);
-  if (!v) { fclose(fp); return NULL; }
+  lsthunk_t* v = ls_eval_arg(args[0], "to_string: arg");
+  if (lsthunk_is_err(v)) { fclose(fp); return v; }
   lsthunk_dprint(fp, LSPREC_LOWEST, 0, v);
   fclose(fp);
   const lsstr_t* str = lsstr_new(buf, len);

--- a/src/lazyscript.c
+++ b/src/lazyscript.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include "runtime/effects.h"
 #include "runtime/unit.h"
+#include "runtime/error.h"
 // builtins modules
 #include "builtins/prelude.h"
 #include "builtins/ns.h"
@@ -274,8 +275,14 @@ int main(int argc, char** argv) {
         g_run_main         = 0; // -e は従来通り：最終値を出力
         lsthunk_t* ret     = lsprog_eval(prog, tenv);
         if (ret != NULL) {
-          lsthunk_print(stdout, LSPREC_LOWEST, 0, ret);
-          lsprintf(stdout, 0, "\n");
+          if (lsthunk_is_err(ret)) {
+            lsprintf(stderr, 0, "E: ");
+            lsthunk_print(stderr, LSPREC_LOWEST, 0, ret);
+            lsprintf(stderr, 0, "\n");
+          } else {
+            lsthunk_print(stdout, LSPREC_LOWEST, 0, ret);
+            lsprintf(stdout, 0, "\n");
+          }
         }
         g_run_main = saved_run_main;
       }
@@ -419,8 +426,14 @@ int main(int argc, char** argv) {
       ls_maybe_eval_init(tenv);
       lsthunk_t* ret = lsprog_eval(prog, tenv);
       if (ret != NULL && !ls_maybe_run_entry(tenv)) {
-        lsthunk_print(stdout, LSPREC_LOWEST, 0, ret);
-        lsprintf(stdout, 0, "\n");
+        if (lsthunk_is_err(ret)) {
+          lsprintf(stderr, 0, "E: ");
+          lsthunk_print(stderr, LSPREC_LOWEST, 0, ret);
+          lsprintf(stderr, 0, "\n");
+        } else {
+          lsthunk_print(stdout, LSPREC_LOWEST, 0, ret);
+          lsprintf(stdout, 0, "\n");
+        }
       }
     }
   }

--- a/src/runtime/error.h
+++ b/src/runtime/error.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "expr/ealge.h"
+#include "expr/expr.h"
+#include "thunk/thunk.h"
+#include "common/str.h"
+
+static inline lsthunk_t* ls_make_err(const char* msg) {
+  const lsstr_t* s = lsstr_cstr(msg);
+  const lsexpr_t* arg = lsexpr_new_str(s);
+  const lsexpr_t* args[1] = { arg };
+  const lsealge_t* eerr = lsealge_new(lsstr_cstr("#err"), 1, args);
+  return lsthunk_new_ealge(eerr, NULL);
+}
+
+static inline int lsthunk_is_err(const lsthunk_t* thunk) {
+  return thunk && lsthunk_get_type(thunk) == LSTTYPE_ALGE &&
+         lsstrcmp(lsthunk_get_constr(thunk), lsstr_cstr("#err")) == 0;
+}
+
+static inline lsthunk_t* ls_eval_arg(lsthunk_t* arg, const char* msg) {
+  lsthunk_t* v = lsthunk_eval0(arg);
+  if (!v) return ls_make_err(msg);
+  if (lsthunk_is_err(v)) return v;
+  return v;
+}

--- a/test/t25_require_missing.out
+++ b/test/t25_require_missing.out
@@ -1,1 +1,1 @@
-
+E: #err "require: not found"


### PR DESCRIPTION
## Summary
- introduce `#err` algebraic value and helpers
- propagate errors through builtins and thunk evaluation
- surface uncaught `#err` values as user-facing errors
- document required build dependencies
- update missing module test to expect new `#err` message
- simplify builtin argument evaluation by relying on `ls_eval_arg` for error propagation

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a5049f055c8327987efcd8d208a5fa