### PR TITLE
Use !! for namespace literals

### DIFF
--- a/test/t29_ns_literal.ls
+++ b/test/t29_ns_literal.ls
@@ -1,4 +1,4 @@
 !{
-	ns <- { Foo = (~add 41 1) };
+        ns <- !!{ Foo = (~add 41 1) };
 	~~println (~to_str ((~ns Foo)))
 };

--- a/test/t30_ns_literal_use.ls
+++ b/test/t30_ns_literal_use.ls
@@ -1,5 +1,5 @@
 !{
-  ns <- { Foo = 42; Inc = (\~n -> (~add ~n 1)) };
+  ns <- !!{ Foo = 42; Inc = (\~n -> (~add ~n 1)) };
   ~~println (~to_str ((~ns Foo)));
   ~~println (~to_str (((~ns Inc) 41)));
 };

--- a/test/z_tmp_inc_only.ls
+++ b/test/z_tmp_inc_only.ls
@@ -1,4 +1,4 @@
 !{
-  ns <- { Inc = (\n -> (~add n 1)) };
+  ns <- !!{ Inc = (\n -> (~add n 1)) };
   ~~println (~to_str (((~ns Inc) 41)));
 };


### PR DESCRIPTION
## Summary
- require `!!{}` for anonymous namespace literals and reserve `{}`
- adjust parser conflict count
- update namespace literal tests

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `cd test && LAZYSCRIPT_PATH="..:$(pwd)" ./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a50e28ccd88327984cf6d5c914bd72