### PR TITLE
Implement missing prelude helpers

### DIFF
--- a/src/builtins/builtin_loader.c
+++ b/src/builtins/builtin_loader.c
@@ -83,6 +83,11 @@ static void build_search_paths(char* out, size_t outsz) {
     append_path(out, outsz, tmp, NULL);
     snprintf(tmp, sizeof(tmp), "%s/plugins", exedir);
     append_path(out, outsz, tmp, NULL);
+    // When executed from the build tree, shared objects live in .libs/
+    snprintf(tmp, sizeof(tmp), "%s/builtins/.libs", exedir);
+    append_path(out, outsz, tmp, NULL);
+    snprintf(tmp, sizeof(tmp), "%s/plugins/.libs", exedir);
+    append_path(out, outsz, tmp, NULL);
   }
   // Fallback system paths
   append_path(out, outsz, "/usr/local/lib/lazyscript", NULL);
@@ -103,9 +108,10 @@ static lsthunk_t* make_symbol_key(const char* name) {
   char buf[256];
   size_t n = strlen(name);
   if (n + 2 >= sizeof(buf)) n = sizeof(buf) - 2; // truncate long names
-  buf[0] = '.'; memcpy(buf + 1, name, n); buf[1 + n] = '\0';
-  const lsealge_t* ea = lsealge_new(lsstr_cstr(buf), 0, NULL);
-  return lsthunk_new_ealge(ea, NULL);
+  buf[0] = '.';
+  memcpy(buf + 1, name, n);
+  buf[1 + n] = '\0';
+  return lsthunk_new_symbol(lsstr_cstr(buf));
 }
 
 static lsthunk_t* build_namespace_from_module(const ls_builtin_module_t* mod) {

--- a/src/lazyscript.c
+++ b/src/lazyscript.c
@@ -189,6 +189,9 @@ static const char* ls_find_prelude_so(char* buf, size_t bufsz) {
   if (exedir[0]) {
     snprintf(buf, bufsz, "%s/plugins/liblazyscript_prelude.so", exedir);
     if (file_exists(buf)) return buf;
+    // When running from build tree, plugin resides in .libs/
+    snprintf(buf, bufsz, "%s/plugins/.libs/liblazyscript_prelude.so", exedir);
+    if (file_exists(buf)) return buf;
   }
   snprintf(buf, bufsz, "/usr/local/lib/lazyscript/liblazyscript_prelude.so");
   if (file_exists(buf)) return buf;

--- a/src/plugins/prelude_plugin.c
+++ b/src/plugins/prelude_plugin.c
@@ -3,6 +3,7 @@
 #include "expr/ealge.h"
 #include "common/str.h"
 #include "common/io.h"
+#include "runtime/effects.h"
 #include <stdlib.h>
 #include <gc.h>
 #include <assert.h>
@@ -12,10 +13,18 @@ static lsthunk_t* ls_make_unit(void) {
   return lsthunk_new_ealge(eunit, NULL);
 }
 
+static lsthunk_t* pl_getter0(lssize_t argc, lsthunk_t* const* args, void* data) {
+  (void)argc; (void)args; return (lsthunk_t*)data;
+}
+
 static lsthunk_t* pl_exit(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)data;
   assert(argc == 1);
   assert(args != NULL);
+  if (!ls_effects_allowed()) {
+    lsprintf(stderr, 0, "E: exit: effect used in pure context (enable seq/chain)\n");
+    return NULL;
+  }
   lsthunk_t* val = lsthunk_eval0(args[0]);
   if (val == NULL)
     return NULL;
@@ -31,6 +40,10 @@ static lsthunk_t* pl_println(lssize_t argc, lsthunk_t* const* args, void* data) 
   (void)data;
   assert(argc == 1);
   assert(args != NULL);
+  if (!ls_effects_allowed()) {
+    lsprintf(stderr, 0, "E: println: effect used in pure context (enable seq/chain)\n");
+    return NULL;
+  }
   lsthunk_t* thunk_str = lsthunk_eval0(args[0]);
   if (thunk_str == NULL)
     return NULL;
@@ -45,16 +58,72 @@ static lsthunk_t* pl_println(lssize_t argc, lsthunk_t* const* args, void* data) 
   return ls_make_unit();
 }
 
+static lsthunk_t* pl_def(lssize_t argc, lsthunk_t* const* args, void* data) {
+  lstenv_t* tenv = (lstenv_t*)data;
+  assert(argc == 2);
+  assert(args != NULL);
+  if (!ls_effects_allowed()) {
+    lsprintf(stderr, 0, "E: def: effect used in pure context (enable seq/chain)\n");
+    return NULL;
+  }
+  if (!tenv) {
+    lsprintf(stderr, 0, "E: def: no env\n");
+    return NULL;
+  }
+  lsthunk_t* namev = lsthunk_eval0(args[0]);
+  if (namev == NULL)
+    return NULL;
+  if (lsthunk_get_type(namev) != LSTTYPE_ALGE || lsthunk_get_argc(namev) != 0) {
+    lsprintf(stderr, 0, "E: def: expected bare symbol\n");
+    return NULL;
+  }
+  const lsstr_t* name = lsthunk_get_constr(namev);
+  lsthunk_t* val = lsthunk_eval0(args[1]);
+  if (val == NULL)
+    return NULL;
+  lstenv_put_builtin(tenv, name, 0, pl_getter0, val);
+  return ls_make_unit();
+}
+
+// Forward to host implementations for module loading
+extern lsthunk_t* lsbuiltin_prelude_require(lssize_t, lsthunk_t* const*, void*);
+extern lsthunk_t* lsbuiltin_prelude_require_pure(lssize_t, lsthunk_t* const*, void*);
+
+static lsthunk_t* pl_require(lssize_t argc, lsthunk_t* const* args, void* data) {
+  lstenv_t* tenv = (lstenv_t*)data;
+  return lsbuiltin_prelude_require(argc, args, tenv);
+}
+
+static lsthunk_t* pl_require_pure(lssize_t argc, lsthunk_t* const* args, void* data) {
+  lstenv_t* tenv = (lstenv_t*)data;
+  return lsbuiltin_prelude_require_pure(argc, args, tenv);
+}
+
 static lsthunk_t* pl_chain(lssize_t argc, lsthunk_t* const* args, void* data) {
   (void)data;
   assert(argc == 2);
   assert(args != NULL);
+  ls_effects_begin();
   lsthunk_t* action = lsthunk_eval0(args[0]);
+  ls_effects_end();
   if (action == NULL)
     return NULL;
   lsthunk_t* unit = ls_make_unit();
   lsthunk_t* cont = args[1];
   return lsthunk_eval(cont, 1, &unit);
+}
+
+static lsthunk_t* pl_bind(lssize_t argc, lsthunk_t* const* args, void* data) {
+  (void)data;
+  assert(argc == 2);
+  assert(args != NULL);
+  ls_effects_begin();
+  lsthunk_t* val = lsthunk_eval0(args[0]);
+  ls_effects_end();
+  if (val == NULL)
+    return NULL;
+  lsthunk_t* cont = args[1];
+  return lsthunk_eval(cont, 1, &val);
 }
 
 static lsthunk_t* pl_return(lssize_t argc, lsthunk_t* const* args, void* data) {
@@ -64,20 +133,19 @@ static lsthunk_t* pl_return(lssize_t argc, lsthunk_t* const* args, void* data) {
   return args[0];
 }
 
-static lsthunk_t* pl_plugin_hello(lssize_t argc, lsthunk_t* const* args, void* data) {
-  (void)argc; (void)args; (void)data;
+static lsthunk_t* pl_plugin_hello(void) {
   return lsthunk_new_str(lsstr_cstr("plugin"));
 }
 
 static lsthunk_t* pl_dispatch(lssize_t argc, lsthunk_t* const* args, void* data) {
-  (void)data;
+  lstenv_t* tenv = (lstenv_t*)data;
   assert(argc == 1);
   assert(args != NULL);
   lsthunk_t* key = lsthunk_eval0(args[0]);
   if (key == NULL)
     return NULL;
   if (lsthunk_get_type(key) != LSTTYPE_ALGE || lsthunk_get_argc(key) != 0) {
-    lsprintf(stderr, 0, "E: prelude: expected a bare symbol (exit/println/chain/return)\n");
+    lsprintf(stderr, 0, "E: prelude: expected a bare symbol (exit/println/chain/bind/return)\n");
     return NULL;
   }
   const lsstr_t* name = lsthunk_get_constr(key);
@@ -85,12 +153,20 @@ static lsthunk_t* pl_dispatch(lssize_t argc, lsthunk_t* const* args, void* data)
     return lsthunk_new_builtin(lsstr_cstr("prelude.exit"), 1, pl_exit, NULL);
   if (lsstrcmp(name, lsstr_cstr("println")) == 0)
     return lsthunk_new_builtin(lsstr_cstr("prelude.println"), 1, pl_println, NULL);
+  if (lsstrcmp(name, lsstr_cstr("def")) == 0)
+    return lsthunk_new_builtin(lsstr_cstr("prelude.def"), 2, pl_def, tenv);
+  if (lsstrcmp(name, lsstr_cstr("require")) == 0)
+    return lsthunk_new_builtin(lsstr_cstr("prelude.require"), 1, pl_require, tenv);
+  if (lsstrcmp(name, lsstr_cstr("requirePure")) == 0)
+    return lsthunk_new_builtin(lsstr_cstr("prelude.requirePure"), 1, pl_require_pure, tenv);
   if (lsstrcmp(name, lsstr_cstr("chain")) == 0)
     return lsthunk_new_builtin(lsstr_cstr("prelude.chain"), 2, pl_chain, NULL);
+  if (lsstrcmp(name, lsstr_cstr("bind")) == 0)
+    return lsthunk_new_builtin(lsstr_cstr("prelude.bind"), 2, pl_bind, NULL);
   if (lsstrcmp(name, lsstr_cstr("return")) == 0)
     return lsthunk_new_builtin(lsstr_cstr("prelude.return"), 1, pl_return, NULL);
   if (lsstrcmp(name, lsstr_cstr("pluginHello")) == 0)
-    return lsthunk_new_builtin(lsstr_cstr("prelude.pluginHello"), 0, pl_plugin_hello, NULL);
+    return pl_plugin_hello();
   lsprintf(stderr, 0, "E: prelude: unknown symbol: ");
   lsstr_print_bare(stderr, LSPREC_LOWEST, 0, name);
   lsprintf(stderr, 0, "\n");
@@ -100,6 +176,6 @@ static lsthunk_t* pl_dispatch(lssize_t argc, lsthunk_t* const* args, void* data)
 int ls_prelude_register(lstenv_t* tenv) {
   if (!tenv)
     return -1;
-  lstenv_put_builtin(tenv, lsstr_cstr("prelude"), 1, pl_dispatch, NULL);
+  lstenv_put_builtin(tenv, lsstr_cstr("prelude"), 1, pl_dispatch, tenv);
   return 0;
 }


### PR DESCRIPTION
## Summary
- guard prelude plugin helpers with effect checks and support new ops like `def`, `require`, and `requirePure`
- search build-tree `.libs` directory when auto-discovering prelude plugin

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `make check` *(fails: missing `nsnew`/`nsdef` in prelude plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d145915c8327bb73e30658222cab