### PR TITLE
feat: update formatter to latest parser

### DIFF
--- a/src/lazyscript_format.c
+++ b/src/lazyscript_format.c
@@ -4,14 +4,22 @@
 #include "parser/lexer.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 
 // Local parse helper (duplicated from lazyscript.c)
+static const char*     g_sugar_ns = NULL;
+
 static const lsprog_t* lsparse_stream_local(const char* filename, FILE* in_str) {
+  assert(in_str != NULL);
   yyscan_t yyscanner;
   yylex_init(&yyscanner);
   lsscan_t* lsscan = lsscan_new(filename);
   yyset_in(in_str, yyscanner);
   yyset_extra(lsscan, yyscanner);
+  if (g_sugar_ns == NULL)
+    g_sugar_ns = getenv("LAZYSCRIPT_SUGAR_NS");
+  if (g_sugar_ns && g_sugar_ns[0])
+    lsscan_set_sugar_ns(lsscan, g_sugar_ns);
   int             ret  = yyparse(yyscanner);
   const lsprog_t* prog = ret == 0 ? lsscan_get_prog(lsscan) : NULL;
   yylex_destroy(yyscanner);


### PR DESCRIPTION
## Summary
- update lazyscript formatter parser helper to respect `LAZYSCRIPT_SUGAR_NS`

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `test/run-tests.sh` *(fails: t24_namespace_basic, t25_require_missing, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dc788bc48327aaab3ae060605843