### PR TITLE
Document nslit debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ sudo make install   # 任意
   - `LAZYSCRIPT_USE_LIBC_ALLOC=1`: ランタイムのアロケータを Boehm GC から libc に切替えます。
     - デバッグ用途。長時間プロセスでの GC 動作検証とは別に、メモリまわりの問題切り分けに役立ちます。
     - この変数が真の場合、起動時の `GC_init()` もスキップされます。
+  - `LS_NS_LOG_NSLIT`: 名前空間リテラル（nslit）の評価をデバッグ出力します。非空かつ `0` 以外の値で有効。詳細は `docs/10_namespaces.md` を参照。
 
 ### 実行セマンティクスの要点
 

--- a/docs/10_namespaces.md
+++ b/docs/10_namespaces.md
@@ -36,8 +36,8 @@ LazyScript の名前空間は「シンボルキーから値への写像」を提
 
 ```
 !{
-  ns <- (~~nsnew0);
-  (~~nsdefv ns .Foo 42);
+  ~ns <- (~~nsnew0);
+  (~~nsdefv ~ns .Foo 42);
   ~~println (~to_str ((~ns .Foo)))  # => 42
 };
 ```
@@ -46,7 +46,7 @@ LazyScript の名前空間は「シンボルキーから値への写像」を提
 
 ```
 !{
-  ns <- (~~nsnew0);
+  ~ns <- (~~nsnew0);
   ((~ns .__set) .Foo 42);
   ~~println (~to_str ((~ns .Foo)))  # => 42
 };
@@ -64,11 +64,11 @@ LazyScript の名前空間は「シンボルキーから値への写像」を提
 
 ```
 !{
-  ns <- { .Foo = 42; .Bar = ~Foo; };
+  ~ns <- { .Foo = 42; .Bar = ~Foo; };
   ~~println (~to_str ((~ns .Foo)));        # => 42
   ~~println (~to_str ((~ns .Bar)));        # => 42
   # 次のような更新はエラー（不変のため）:
-  # (~~nsdefv ns .Foo 1)
+  # (~~nsdefv ~ns .Foo 1)
   # ((~ns .__set) .Foo 1)
 };
 ```
@@ -91,7 +91,7 @@ LazyScript の名前空間は「シンボルキーから値への写像」を提
 
   ```
   !{
-    ns <- ((~prelude nsnew0));
+    ~ns <- ((~prelude nsnew0));
     ~~nsdefv ~ns .a 1;
     ~~nsdefv ~ns .b 2;
     ~~nsdefv ~ns .aa 3;
@@ -105,9 +105,31 @@ strict-effects 有効時の例（トークンが必要）:
 
 ```
 !{
-  ns <- ((~prelude chain) ((~prelude nsnew0)) (\~x -> ~x));
+  ~ns <- ((~prelude chain) ((~prelude nsnew0)) (\~x -> ~x));
   ((~prelude chain) (~~nsdefv ~ns .x 1) (\~_ -> ()));
   ((~prelude nsMembers) ~ns)
 };
 -- 出力: [.x]
 ```
+
+## nslit デバッグログ
+
+環境変数 `LS_NS_LOG_NSLIT` を設定すると、名前空間リテラル（nslit）の評価過程を stderr にログ出力します。値が空文字列または `0` 以外であれば有効になります（既定はオフ）。
+
+### 例
+
+```bash
+LS_NS_LOG_NSLIT=1 ./src/lazyscript -e '!{ ~ns <- { .Foo = 1; }; (~ns .Foo); };'
+```
+
+出力例:
+
+```
+DBG nslit begin argc=2
+DBG nslit key[0] eval
+DBG nslit key=S.Foo
+DBG nslit val[0] eval
+DBG nslit put type=3
+DBG nslit end ns=0x... map=0x...
+```
+


### PR DESCRIPTION
## Summary
- document LS_NS_LOG_NSLIT environment variable in README
- add documentation and example for nslit debug logging in docs/10_namespaces.md
- fix namespace literal examples to use `~ns <-` and update nslit log snippet

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `make check -j$(nproc)` *(fails: FAIL: test/run-tests.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a72bc49aa883278ed80e92e7415a14