### PR TITLE
test: normalize /workspaces path in test harness

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -26,10 +26,12 @@ normalize_stream() {
     sed -E \
       -e "s|$ROOT|<ROOT>|g" \
       -e "s|$gw|<ROOT>|g" \
+  -e 's|/workspaces/lazyscript|<ROOT>|g' \
       -e 's|/home/runner/work/[^/]+/[^/]+|<ROOT>|g'
   else
     sed -E \
       -e "s|$ROOT|<ROOT>|g" \
+  -e 's|/workspaces/lazyscript|<ROOT>|g' \
       -e 's|/home/runner/work/[^/]+/[^/]+|<ROOT>|g'
   fi
 }


### PR DESCRIPTION
Normalize /workspaces/lazyscript to <ROOT> in test/run-tests.sh so CI vs dev paths compare identically. This should fix libc job failures where expected paths contained <ROOT> but actual outputs used /workspaces.